### PR TITLE
Fix possible bug with not having a CHANGELOG file

### DIFF
--- a/Source/action.ts
+++ b/Source/action.ts
@@ -41,7 +41,7 @@ function createChangelogContent(body: string, version: string, prUrl: string): s
 }
 
 function writeToFile(filePath: string, content: string[]) {
-    readFile(filePath, (err, data) => {
+    readFile(filePath, { flag: 'w' }, (err, data) => {
         if (err) fail(err);
         const oldContent = data.toString().split('\n');
         oldContent.unshift(...content);


### PR DESCRIPTION
## Summary

If the repo doesn't have the specified changelog file, create one.

### Fixed

- Creates the changelog file if not found, so that it doesn't crash

