### PR TITLE
Commit and push

### DIFF
--- a/.github/workflows/github-javascript-actions-ci.yml
+++ b/.github/workflows/github-javascript-actions-ci.yml
@@ -54,18 +54,6 @@ jobs:
         body: ${{ steps.context.outputs.pr-body }}
         pr-url: ${{ steps.context.outputs.pr-url }}
         changelog-path: CHANGELOG.md
+        user-email: build@dolittle.com
+        user-name: dolittle-build
 
-    - name: Commit changelog
-      if: ${{ steps.context.outputs.should-publish == 'true' }}
-      run: |
-        git config --local user.email "build@dolittle.com"
-        git config --local user.name "dolittle-build"
-        git add CHANGELOG.md
-        git commit -m "Add version ${{ steps.increment-version.outputs.next-version }} to changelog"
-
-    - name: Push changes
-      if: ${{ steps.context.outputs.should-publish == 'true' }}
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: 'master'

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # GitHub Action - Add To Changelog
 ![Github JavaScript Actions CI/CD](https://github.com/dolittle/add-to-changelog-action/workflows/Github%20JavaScript%20Actions%20CI/CD/badge.svg)
 
-This GitHub action prepends the release note from the PR body to the CHANGELOG.md file
+This GitHub action prepends the release note from the PR body to the CHANGELOG.md file and commits and pushes the file to the current branch.
 
 ### Inputs
 - `version`: The version released
 - `body`: The main text to add to the changelog
 - `pr-url`: URL to the PR that resulted in the release
 - `changelog-path`: Path to the CHANGELOG.md file. Defaults to `CHANGELOG.md` in repo root.
+- `user-email`: The email of the user that should commit the CHANGELOG
+- `user-name`: The name of the user that should commit the CHANGELOG
+- `token`: The token used to push the commit. Defaults to `${{ secrets.GITHUB_TOKEN }}`
 
 ### Example Workflow
 ```yaml
@@ -55,27 +58,15 @@ jobs:
 
     - name: Prepend to Changelog
       if: ${{ steps.context.outputs.should-publish == 'true' }}
-      uses: ./
+      uses: dolittle/add-to-changelog-action@v2
       with:
         version: ${{ steps.increment-version.outputs.next-version }}
         body: ${{ steps.context.outputs.pr-body }}
         pr-url: ${{ steps.context.outputs.pr-url }}
         changelog-path: CHANGELOG.md
-
-    - name: Commit changelog
-      if: ${{ steps.context.outputs.should-publish == 'true' }}
-      run: |
-        git config --local user.email "build@dolittle.com"
-        git config --local user.name "dolittle-build"
-        git add CHANGELOG.md
-        git commit -m "Add version ${{ steps.increment-version.outputs.next-version }} to changelog"
-
-    - name: Push changes
-      if: ${{ steps.context.outputs.should-publish == 'true' }}
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: 'master'
+        user-email: some-email@company.com
+        user-name: some-name
+        token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Contributing

--- a/Source/action.ts
+++ b/Source/action.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import path from 'path';
 import { getInput, setFailed } from '@actions/core';
+import { exec } from '@actions/exec';
+import * as github from '@actions/github';
 import { Logger } from '@dolittle/github-actions.shared.logging';
 import { readFile, writeFile } from 'fs';
 
@@ -14,14 +17,20 @@ export async function run() {
         const body = getInput('body', { required: true });
         const prUrl = getInput('pr-url', { required: true });
         const changelogPath = getInput('changelog-path', { required: true });
+        const userEmail = getInput('user-email', { required: true });
+        const userName = getInput('user-name', { required: true });
+        const token = getInput('token', { required: true });
 
         logger.info(`Creating new content for changelog with version ${version}`);
         const content = createChangelogContent(body, version, prUrl);
 
         logger.info(`Writing to path ${changelogPath} with heading ${content[0]} and ${content.length} lines of new content`);
         writeToFile(changelogPath, content);
-
         logger.info('Write complete');
+        await configureUser(userEmail, userName);
+        await commitChangelog(changelogPath, version);
+        await pushChanges();
+
     } catch (error) {
         fail(error);
     }
@@ -50,4 +59,43 @@ function writeToFile(filePath: string, content: string[]) {
             if (err) fail(new Error(err.message));
         });
     });
+}
+
+async function pushChanges() {
+    const branchName = path.basename(github.context.ref);
+    logger.info(`Pushing changelog to origin ${branchName}`);
+    await exec(
+        `git push origin ${branchName}`,
+        undefined,
+        { ignoreReturnCode: true});
+}
+async function configureUser(userEmail: string, userName: string) {
+    logger.info(`Configuring user with email '${userEmail}' and name '${userName}'`);
+    await exec(
+        'git config',
+        [
+            'user.email',
+            `"${userEmail}"`
+        ],
+        { ignoreReturnCode: true});
+    await exec(
+        'git config',
+        [
+            'user.name',
+            `"${userName}"`
+        ],
+        { ignoreReturnCode: true});
+}
+async function commitChangelog(changelogPath: string, version: string) {
+    logger.info(`Adding and committing ${changelogPath}`);
+    await exec(
+        'git add',
+        [changelogPath],
+        { ignoreReturnCode: true});
+    await exec(
+        'git commit',
+        [
+            `-m "Add version ${version} ${changelogPath}"`
+        ],
+        { ignoreReturnCode: true});
 }

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,16 @@ inputs:
     description: The relative path to the changelog file
     required: false
     default: 'CHANGELOG.md'
+  user-email:
+    description: The email of the user that commits the CHANGELOG
+    required: true
+  user-name:
+    description: The name of the user that commits the CHANGELOG
+    required: true
+  token:
+    description: The token used for pushing the CHANGELOG
+    required: false
+    default: ${{ secrets.GITHUB_TOKEN }}
 
 runs:
   using: 'node12'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@actions/core": "^1.2.4",
+    "@actions/exec": "1.0.4",
+    "@actions/github": "4.0.0",
     "@dolittle/github-actions.shared.logging": "^1.1.1",
     "@dolittle/github-actions.shared.rudiments": "^1.1.1"
   }


### PR DESCRIPTION
## Summary

This action now also commits and pushes the changelog file to the branch it's committed to.

This is a breaking change because it adds new required inputs.

### Added

- 'user-name' input for configuring git user.name
- 'user-email' input for configuring git user.email
- 'token' input used as the token that pushes the changes. (Not actually in use yet)
- This action now commits and pushes the changed changelog to the branch that correlates to 'context.ref' 

### Changed

- README
- Workflow so that it uses the new inputs of this action