### PR TITLE
Fix and error in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   token:
     description: The token used for pushing the CHANGELOG
     required: false
-    default: ${{ secrets.GITHUB_TOKEN }}
+    default: ${{ github.token }}
 
 runs:
   using: 'node12'


### PR DESCRIPTION
## Summary

Fixes the 'token' input in the action.yml configuration

### Fixed

- Changed 'token' default value to '${{ github.token }}'
