### PR TITLE
Create the release after committing changelog

### DIFF
--- a/.github/workflows/github-javascript-actions-ci.yml
+++ b/.github/workflows/github-javascript-actions-ci.yml
@@ -38,14 +38,6 @@ jobs:
         version: ${{ steps.context.outputs.current-version }}
         release-type: ${{ steps.context.outputs.release-type }}
 
-    - name: Create GitHub Release
-      if: ${{ steps.context.outputs.should-publish == 'true' }}
-      uses: dolittle/github-release-action@v2
-      with:
-        token: ${{  secrets.BUILD_PAT  }}
-        version: ${{ steps.increment-version.outputs.next-version }}
-        body: ${{ steps.context.outputs.pr-body }}
-
     - name: Prepend to Changelog
       if: ${{ steps.context.outputs.should-publish == 'true' }}
       uses: ./
@@ -57,3 +49,10 @@ jobs:
         user-email: build@dolittle.com
         user-name: dolittle-build
 
+    - name: Create GitHub Release
+      if: ${{ steps.context.outputs.should-publish == 'true' }}
+      uses: dolittle/github-release-action@v2
+      with:
+        token: ${{  secrets.BUILD_PAT  }}
+        version: ${{ steps.increment-version.outputs.next-version }}
+        body: ${{ steps.context.outputs.pr-body }}

--- a/README.md
+++ b/README.md
@@ -48,14 +48,6 @@ jobs:
         version: ${{ steps.context.outputs.current-version }}
         release-type: ${{ steps.context.outputs.release-type }}
 
-    - name: Create GitHub Release
-      if: ${{ steps.context.outputs.should-publish == 'true' }}
-      uses: dolittle/github-release-action@v2
-      with:
-        token: ${{  secrets.BUILD_PAT  }}
-        version: ${{ steps.increment-version.outputs.next-version }}
-        body: ${{ steps.context.outputs.pr-body }}
-
     - name: Prepend to Changelog
       if: ${{ steps.context.outputs.should-publish == 'true' }}
       uses: dolittle/add-to-changelog-action@v2
@@ -67,6 +59,14 @@ jobs:
         user-email: some-email@company.com
         user-name: some-name
         token: ${{ github.token }}
+
+    - name: Create GitHub Release
+      if: ${{ steps.context.outputs.should-publish == 'true' }}
+      uses: dolittle/github-release-action@v2
+      with:
+        token: ${{  secrets.BUILD_PAT  }}
+        version: ${{ steps.increment-version.outputs.next-version }}
+        body: ${{ steps.context.outputs.pr-body }}
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary

The changelog file should be committed before the release is created in order for the new changelog to be a part of the release.

### Fixed

- Release after changelog is committed
