### PR TITLE
Make action configure pull merge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ This GitHub action prepends the release note from the PR body to the `CHANGELOG.
 - `user-email`: The email of the user that should commit the CHANGELOG
 - `user-name`: The name of the user that should commit the CHANGELOG
 - `token`: The token used to push the commit. Defaults to `${{ secrets.GITHUB_TOKEN }}`
+- `merge-strategy`: How to reconcile divergent branches when pulling.
+  - `merge`: Tries to merge (default)
+  - `rebase`: Tries to rebase
+  - `fast-forward`: Only allows for fast forwards
+
 
 ### Example Workflow
 ```yaml


### PR DESCRIPTION
## Summary

When using this action in a workflow that runs in parallel with other workflows that alos changes the git branch tree this action could fail to pull and push the commit because of no being able to pull the new code because it does not have a configured merge-srategy. This should fix that problem. This is already what we do in the write-version-file-action

### Changed

- Configure pull to use a specific merge-strategy before pulling and pusing commit
